### PR TITLE
배치잡 역할 서비스 레이어로 분리 & 트랜잭션 처리

### DIFF
--- a/devly-batch/src/main/java/se/sowl/devlybatch/common/gpt/GptContentProcessor.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/common/gpt/GptContentProcessor.java
@@ -1,31 +1,76 @@
 package se.sowl.devlybatch.common.gpt;
 
 
+import se.sowl.devlybatch.common.gpt.exception.GPTContentProcessingException;
 import se.sowl.devlyexternal.client.gpt.dto.GPTRequest;
 import se.sowl.devlyexternal.client.gpt.dto.GPTResponse;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public abstract class GptContentProcessor<T> {
-
     public List<T> parseGPTResponse(GPTResponse response, Long studyId) {
+        validateResponse(response);
         List<T> contents = new ArrayList<>();
         String content = response.getContent();
-        String[] entries = content.split("---");
-        for (String entry : entries) {
-            if (entry.trim().isEmpty()) continue;
-            parseEntity(studyId, entry, contents);
+        try {
+            String[] entries = content.split("---");
+            validateEntries(entries);
+            for (String entry : entries) {
+                if (entry.trim().isEmpty()) continue;
+                parseEntity(studyId, entry, contents);
+            }
+            if (contents.isEmpty()) {
+                throw new GPTContentProcessingException("Failed to parse any valid entities from GPT response");
+            }
+            return contents;
+        } catch (Exception e) {
+            handleException(e);
+            return Collections.emptyList();
         }
-        return contents;
     }
 
     public GPTRequest createGPTRequest(String prompt) {
-        return GPTRequest.builder()
-            .model("gpt-4")
-            .messages(List.of(GPTRequest.Message.builder().role("user").content(prompt).build()))
-            .temperature(0.7)
-            .build();
+        if (prompt == null || prompt.trim().isEmpty()) {
+            throw new GPTContentProcessingException("Prompt cannot be null or empty");
+        }
+        try {
+            return GPTRequest.builder()
+                .model("gpt-4")
+                .messages(List.of(GPTRequest.Message.builder()
+                    .role("user")
+                    .content(prompt)
+                    .build()))
+                .temperature(0.7)
+                .build();
+        } catch (Exception e) {
+            throw new GPTContentProcessingException("Failed to create GPT request: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateResponse(GPTResponse response) {
+        if (response == null) {
+            throw new GPTContentProcessingException("GPT response is null");
+        }
+
+        String content = response.getContent();
+        if (content == null || content.trim().isEmpty()) {
+            throw new GPTContentProcessingException("GPT response content is empty");
+        }
+    }
+
+    private void validateEntries(String[] entries) {
+        if (entries.length == 0 || (entries.length == 1 && entries[0].trim().isEmpty())) {
+            throw new GPTContentProcessingException("No entries found in GPT response");
+        }
+    }
+
+    private void handleException(Exception e) {
+        if (e instanceof GPTContentProcessingException) {
+            throw (GPTContentProcessingException) e;
+        }
+        throw new GPTContentProcessingException("Error processing GPT response: " + e.getMessage(), e);
     }
 
     abstract protected void parseEntity(Long studyId, String entry, List<T> contents);

--- a/devly-batch/src/main/java/se/sowl/devlybatch/common/gpt/exception/GPTContentProcessingException.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/common/gpt/exception/GPTContentProcessingException.java
@@ -1,0 +1,11 @@
+package se.sowl.devlybatch.common.gpt.exception;
+
+public class GPTContentProcessingException extends RuntimeException {
+    public GPTContentProcessingException(String message) {
+        super(message);
+    }
+
+    public GPTContentProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/devly-batch/src/main/java/se/sowl/devlybatch/config/BatchProperties.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/config/BatchProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-public class StudyBatchProperties {
+public class BatchProperties {
     @Value("${spring.jpa.properties.hibernate.batch_size}")
     private int chunkSize;
 

--- a/devly-batch/src/main/java/se/sowl/devlybatch/config/StudyBatchProperties.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/config/StudyBatchProperties.java
@@ -2,13 +2,19 @@ package se.sowl.devlybatch.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Getter
 @Setter
 @Configuration
 public class StudyBatchProperties {
-    private int chunkSize = 100;
-    private int retryLimit = 3;
-    private int skipLimit = 10;
+    @Value("${spring.jpa.properties.hibernate.batch_size}")
+    private int chunkSize;
+
+    @Value("${spring.batch.retry-limit}")
+    private int retryLimit;
+
+    @Value("${spring.batch.skip-limit}")
+    private int skipLimit;
 }

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/PrCreationJobConfig.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/PrCreationJobConfig.java
@@ -11,7 +11,6 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.annotation.Transactional;
 import se.sowl.devlybatch.job.pr.service.PrProcessService;
 import se.sowl.devlybatch.job.study.service.StudyService;
 import se.sowl.devlydomain.study.domain.Study;
@@ -34,7 +33,6 @@ public class PrCreationJobConfig {
     }
 
     @Bean
-    @Transactional
     public Step createPrStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
         return new StepBuilder("createPrStep", jobRepository)
             .tasklet((contribution, chunkContext) -> {

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/PrCreationJobConfig.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/PrCreationJobConfig.java
@@ -11,30 +11,20 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
-import se.sowl.devlybatch.job.pr.utils.PrContentProcessor;
-import se.sowl.devlybatch.job.pr.utils.PrPromptManager;
-import se.sowl.devlybatch.service.StudyService;
-import se.sowl.devlydomain.pr.domain.Pr;
-import se.sowl.devlydomain.pr.repository.PrRepository;
+import org.springframework.transaction.annotation.Transactional;
+import se.sowl.devlybatch.job.pr.service.PrProcessService;
+import se.sowl.devlybatch.job.study.service.StudyService;
 import se.sowl.devlydomain.study.domain.Study;
 import se.sowl.devlydomain.study.domain.StudyTypeEnum;
-import se.sowl.devlyexternal.client.gpt.GPTClient;
-import se.sowl.devlyexternal.client.gpt.dto.GPTResponse;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class PrCreationJobConfig {
-
     private final StudyService studyService;
-    private final PrRepository prRepository;
-    private final GPTClient gptClient;
-    private final PrContentProcessor prContentProcessor;
-    private final PrPromptManager prPromptManager;
+    private final PrProcessService prProcessService;
 
     @Bean
     public Job prCreationJob(JobRepository jobRepository, Step createPrStep) {
@@ -44,6 +34,7 @@ public class PrCreationJobConfig {
     }
 
     @Bean
+    @Transactional
     public Step createPrStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
         return new StepBuilder("createPrStep", jobRepository)
             .tasklet((contribution, chunkContext) -> {
@@ -53,35 +44,18 @@ public class PrCreationJobConfig {
             .build();
     }
 
-    private void createTodayPrStudies() {
+    public void createTodayPrStudies() {
         List<Study> todayStudies = studyService.getTodayStudiesOf(StudyTypeEnum.PULL_REQUEST.getId());
+        log.info("Create pr batch started! studies total count: {}", todayStudies.size());
         for (Study study : todayStudies) {
-            GPTResponse response = getPrResponse(study);
-            savePrOf(study, response);
-            log.info("Created Pr for study {}", study.getId());
+            try {
+                prProcessService.processPrStudies(study);
+                log.info("Created pr for study {}", study.getId());
+            } catch (Exception e) {
+                log.error("[Warning] pr create failed : Study ID={}, Error={}", study.getId(), e.getMessage(), e);
+            }
         }
     }
 
-    private GPTResponse getPrResponse(Study study) {
-        String prGeneratePrompt = createPrGeneratePrompt(study);
-        return gptClient.generate(prContentProcessor.createGPTRequest(prGeneratePrompt));
-    }
-
-    private String createPrGeneratePrompt(Study study) {
-        List<String> recentTitles = prRepository.findPrsByCreatedAtAfter(LocalDateTime.now().minusDays(7))
-            .stream().map(Pr::getTitle).collect(Collectors.toList());
-        return generatePrompt(study.getDeveloperTypeId(), recentTitles);
-    }
-
-    private void savePrOf(Study study, GPTResponse response) {
-        prContentProcessor.parseGPTResponse(response, study.getId());
-    }
-
-    private String generatePrompt(Long developerTypeId, List<String> excludeContents) {
-        StringBuilder prompt = new StringBuilder();
-        prPromptManager.addPrompt(developerTypeId, prompt);
-        prPromptManager.addExcludePrompt(excludeContents, prompt);
-        return prompt.toString();
-    }
 }
 

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrContentProcessor.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrContentProcessor.java
@@ -1,4 +1,4 @@
-package se.sowl.devlybatch.job.pr.utils;
+package se.sowl.devlybatch.job.pr.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -89,10 +89,9 @@ public class PrContentProcessor extends GptContentProcessor<Pr> {
     }
 
     private void saveLabels(Long prId, List<String> labels) {
-        for (String label : labels) {
-            PrLabel prLabel = new PrLabel(prId, label);
-            prLabelRepository.save(prLabel);
-        }
+        List<PrLabel> labelsToSave = new ArrayList<>();
+        labels.forEach(label -> labelsToSave.add(new PrLabel(prId, label)));
+        prLabelRepository.saveAll(labelsToSave);
     }
 
     private void processComments(Long prId, String entry) {

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrProcessService.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrProcessService.java
@@ -26,13 +26,9 @@ public class PrProcessService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processPrStudies(Study study) {
-        GPTResponse response = getPrResponse(study);
-        savePrOf(study, response);
-    }
-
-    private GPTResponse getPrResponse(Study study) {
         String prGeneratePrompt = createPrGeneratePrompt(study);
-        return gptClient.generate(prContentProcessor.createGPTRequest(prGeneratePrompt));
+        GPTResponse response = gptClient.generate(prContentProcessor.createGPTRequest(prGeneratePrompt));
+        savePrOf(study, response);
     }
 
     private String createPrGeneratePrompt(Study study) {
@@ -41,14 +37,14 @@ public class PrProcessService {
         return generatePrompt(study.getDeveloperTypeId(), recentTitles);
     }
 
-    private void savePrOf(Study study, GPTResponse response) {
-        prContentProcessor.parseGPTResponse(response, study.getId());
-    }
-
     private String generatePrompt(Long developerTypeId, List<String> excludeContents) {
         StringBuilder prompt = new StringBuilder();
         prPromptManager.addPrompt(developerTypeId, prompt);
         prPromptManager.addExcludePrompt(excludeContents, prompt);
         return prompt.toString();
+    }
+
+    private void savePrOf(Study study, GPTResponse response) {
+        prContentProcessor.parseGPTResponse(response, study.getId());
     }
 }

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrProcessService.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrProcessService.java
@@ -1,0 +1,54 @@
+package se.sowl.devlybatch.job.pr.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import se.sowl.devlydomain.pr.domain.Pr;
+import se.sowl.devlydomain.pr.repository.PrRepository;
+import se.sowl.devlydomain.study.domain.Study;
+import se.sowl.devlyexternal.client.gpt.GPTClient;
+import se.sowl.devlyexternal.client.gpt.dto.GPTResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PrProcessService {
+    private final PrRepository prRepository;
+    private final GPTClient gptClient;
+    private final PrContentProcessor prContentProcessor;
+    private final PrPromptManager prPromptManager;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void processPrStudies(Study study) {
+        GPTResponse response = getPrResponse(study);
+        savePrOf(study, response);
+    }
+
+    private GPTResponse getPrResponse(Study study) {
+        String prGeneratePrompt = createPrGeneratePrompt(study);
+        return gptClient.generate(prContentProcessor.createGPTRequest(prGeneratePrompt));
+    }
+
+    private String createPrGeneratePrompt(Study study) {
+        List<String> recentTitles = prRepository.findPrsByCreatedAtAfter(LocalDateTime.now().minusDays(7))
+            .stream().map(Pr::getTitle).collect(Collectors.toList());
+        return generatePrompt(study.getDeveloperTypeId(), recentTitles);
+    }
+
+    private void savePrOf(Study study, GPTResponse response) {
+        prContentProcessor.parseGPTResponse(response, study.getId());
+    }
+
+    private String generatePrompt(Long developerTypeId, List<String> excludeContents) {
+        StringBuilder prompt = new StringBuilder();
+        prPromptManager.addPrompt(developerTypeId, prompt);
+        prPromptManager.addExcludePrompt(excludeContents, prompt);
+        return prompt.toString();
+    }
+}

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrPromptManager.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/pr/service/PrPromptManager.java
@@ -1,4 +1,4 @@
-package se.sowl.devlybatch.job.pr.utils;
+package se.sowl.devlybatch.job.pr.service;
 
 import org.springframework.stereotype.Component;
 import se.sowl.devlybatch.common.gpt.GptPromptManager;

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/study/service/StudyService.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/study/service/StudyService.java
@@ -2,20 +2,46 @@ package se.sowl.devlybatch.job.study.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.sowl.devlydomain.developer.domain.DeveloperType;
+import se.sowl.devlydomain.developer.repository.DeveloperTypeRepository;
 import se.sowl.devlydomain.study.domain.Study;
+import se.sowl.devlydomain.study.domain.StudyType;
 import se.sowl.devlydomain.study.repository.StudyRepository;
+import se.sowl.devlydomain.study.repository.StudyTypeRepository;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class StudyService {
     private final StudyRepository studyRepository;
+    private final StudyTypeRepository studyTypeRepository;
+    private final DeveloperTypeRepository developerTypeRepository;
 
     public List<Study> getTodayStudiesOf(Long StudyTypeId) {
         LocalDateTime startOfDay = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
         LocalDateTime endOfDay = startOfDay.plusDays(1);
         return studyRepository.findByCreatedAtBetweenAndTypeId(startOfDay, endOfDay, StudyTypeId);
+    }
+
+    @Transactional
+    public List<Study> generateStudiesOf() {
+        // TODO: 스터디 배치 잡이 모두 구현 완료된다면 수정해야 한다. 현재 일부만 구현되었으므로 하드코딩으로 구현
+        List<StudyType> studyTypes = studyTypeRepository.findAll();
+        StudyType wordType = studyTypes.stream().filter(studyType -> studyType.getName().equals("word")).findFirst().get();
+        StudyType prType = studyTypes.stream().filter(studyType -> studyType.getName().equals("pr")).findFirst().get();
+
+        List<DeveloperType> devTypes = developerTypeRepository.findAll();
+        List<Study> studies = new ArrayList<>(List.of());
+        for(DeveloperType devType : devTypes) {
+            Study study = Study.builder().typeId(wordType.getId()).developerTypeId(devType.getId()).build();
+            Study prStudy = Study.builder().typeId(prType.getId()).developerTypeId(devType.getId()).build();
+            studies.add(study);
+            studies.add(prStudy);
+        }
+        return studyRepository.saveAll(studies);
     }
 }

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/study/service/StudyService.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/study/service/StudyService.java
@@ -1,4 +1,4 @@
-package se.sowl.devlybatch.service;
+package se.sowl.devlybatch.job.study.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/StudyAssignmentJobConfig.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/StudyAssignmentJobConfig.java
@@ -18,7 +18,7 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.transaction.PlatformTransactionManager;
 import se.sowl.devlybatch.common.QuerydslPagingItemReader;
-import se.sowl.devlybatch.config.StudyBatchProperties;
+import se.sowl.devlybatch.config.BatchProperties;
 import se.sowl.devlybatch.job.userStudy.service.StudyAssignmentService;
 import se.sowl.devlydomain.user.domain.UserStudy;
 
@@ -29,7 +29,7 @@ public class StudyAssignmentJobConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
     private final EntityManagerFactory entityManagerFactory;
-    private final StudyBatchProperties properties;
+    private final BatchProperties properties;
     private final StudyAssignmentService studyAssignmentService;
 
     @Bean

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/StudyAssignmentJobConfig.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/StudyAssignmentJobConfig.java
@@ -19,16 +19,8 @@ import org.springframework.dao.TransientDataAccessException;
 import org.springframework.transaction.PlatformTransactionManager;
 import se.sowl.devlybatch.common.QuerydslPagingItemReader;
 import se.sowl.devlybatch.config.StudyBatchProperties;
-import se.sowl.devlydomain.study.domain.Study;
-import se.sowl.devlydomain.study.repository.StudyRepository;
+import se.sowl.devlybatch.job.userStudy.service.StudyAssignmentService;
 import se.sowl.devlydomain.user.domain.UserStudy;
-import se.sowl.devlydomain.user.repository.UserStudyRepository;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Configuration
@@ -36,10 +28,9 @@ import java.util.stream.Collectors;
 public class StudyAssignmentJobConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
-    private final UserStudyRepository userStudyRepository;
-    private final StudyRepository studyRepository;
     private final EntityManagerFactory entityManagerFactory;
     private final StudyBatchProperties properties;
+    private final StudyAssignmentService studyAssignmentService;
 
     @Bean
     public Job studyAssignmentJob() {
@@ -78,10 +69,12 @@ public class StudyAssignmentJobConfig {
     @Bean
     @StepScope
     protected ItemReader<UserStudy> completedStudiesReader() {
-        LocalDateTime yesterday = LocalDate.now().minusDays(1).atStartOfDay();
-        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
         return new QuerydslPagingItemReader<>(
-            pageable -> userStudyRepository.findCompletedStudiesWithoutNext(yesterday, todayStart, todayStart, pageable),
+            (pageable) -> {
+                int pageNumber = pageable.getPageNumber();
+                int pageSize = pageable.getPageSize();
+                return studyAssignmentService.findCompletedStudiesWithoutNext(pageNumber, pageSize);
+            },
             properties.getChunkSize()
         );
     }
@@ -89,52 +82,7 @@ public class StudyAssignmentJobConfig {
     @Bean
     @StepScope
     protected ItemProcessor<UserStudy, UserStudy> nextStudyProcessor() {
-        List<Study> orderedStudies = studyRepository.findAllByOrderById();
-        Map<Long, Study> studyMap = orderedStudies.stream().collect(Collectors.toMap(Study::getId, s -> s));
-        return completed -> {
-            Study completedStudy = getCompletedStudy(completed, studyMap);
-            if (completedStudy == null) return null;
-            Study nextStudy = getNextStudy(completed, orderedStudies, completedStudy);
-            if (nextStudy == null) return null;
-            return UserStudy.builder()
-                .userId(completed.getUserId())
-                .study(nextStudy)
-                .scheduledAt(LocalDateTime.now())
-                .build();
-        };
-    }
-
-    private static Study getCompletedStudy(UserStudy completed, Map<Long, Study> studyMap) {
-        Study completedStudy = studyMap.get(completed.getStudy().getId());
-        if (completedStudy == null) {
-            log.warn("Completed study not found: {}", completed.getId());
-            return null;
-        }
-        return completedStudy;
-    }
-
-    private static Study getNextStudy(UserStudy completed, List<Study> orderedStudies, Study completedStudy) {
-        Study nextStudy = findNextStudy(orderedStudies, completedStudy);
-        if (nextStudy == null) {
-            log.info("No next study found for user: {}, type: {}, devType: {}",
-                completed.getUserId(), completedStudy.getTypeId(), completedStudy.getDeveloperTypeId());
-            return null;
-        }
-        return nextStudy;
-    }
-
-    public static Study findNextStudy(List<Study> allStudies, Study currentStudy) {
-        boolean foundCurrent = false;
-        for (Study study : allStudies) {
-            if (foundCurrent && isSameStudyType(currentStudy, study)) return study;
-            else if (study.getId().equals(currentStudy.getId())) foundCurrent = true;
-        }
-        return null;
-    }
-
-    private static boolean isSameStudyType(Study currentStudy, Study study) {
-        return study.getTypeId().equals(currentStudy.getTypeId()) &&
-            study.getDeveloperTypeId().equals(currentStudy.getDeveloperTypeId());
+        return studyAssignmentService::assignNextStudy;
     }
 
     @Bean

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/service/StudyAssignmentService.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/service/StudyAssignmentService.java
@@ -27,8 +27,7 @@ public class StudyAssignmentService {
     @Transactional
     public UserStudy assignNextStudy(UserStudy completedUserStudy) {
         List<Study> orderedStudies = studyRepository.findAllByOrderById();
-        Map<Long, Study> studyMap = orderedStudies.stream()
-            .collect(Collectors.toMap(Study::getId, s -> s));
+        Map<Long, Study> studyMap = orderedStudies.stream().collect(Collectors.toMap(Study::getId, s -> s));
 
         Study completedStudy = getCompletedStudy(completedUserStudy, studyMap);
         if (completedStudy == null) return null;

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/service/StudyAssignmentService.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/userStudy/service/StudyAssignmentService.java
@@ -1,0 +1,88 @@
+package se.sowl.devlybatch.job.userStudy.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.sowl.devlydomain.study.domain.Study;
+import se.sowl.devlydomain.study.repository.StudyRepository;
+import se.sowl.devlydomain.user.domain.UserStudy;
+import se.sowl.devlydomain.user.repository.UserStudyRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudyAssignmentService {
+    private final UserStudyRepository userStudyRepository;
+    private final StudyRepository studyRepository;
+
+    @Transactional
+    public UserStudy assignNextStudy(UserStudy completedUserStudy) {
+        List<Study> orderedStudies = studyRepository.findAllByOrderById();
+        Map<Long, Study> studyMap = orderedStudies.stream()
+            .collect(Collectors.toMap(Study::getId, s -> s));
+
+        Study completedStudy = getCompletedStudy(completedUserStudy, studyMap);
+        if (completedStudy == null) return null;
+
+        Study nextStudy = getNextStudy(completedUserStudy, orderedStudies, completedStudy);
+        if (nextStudy == null) return null;
+
+        return UserStudy.builder()
+            .userId(completedUserStudy.getUserId())
+            .study(nextStudy)
+            .scheduledAt(LocalDateTime.now())
+            .build();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserStudy> findCompletedStudiesWithoutNext(int page, int size) {
+        LocalDateTime yesterday = LocalDate.now().minusDays(1).atStartOfDay();
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+
+        return userStudyRepository.findCompletedStudiesWithoutNext(
+            yesterday, todayStart, todayStart,
+            PageRequest.of(page, size));
+    }
+
+    private Study findNextStudy(List<Study> allStudies, Study currentStudy) {
+        boolean foundCurrent = false;
+        for (Study study : allStudies) {
+            if (foundCurrent && isSameStudyType(currentStudy, study)) return study;
+            else if (study.getId().equals(currentStudy.getId())) foundCurrent = true;
+        }
+        return null;
+    }
+
+    private Study getCompletedStudy(UserStudy completed, Map<Long, Study> studyMap) {
+        Study completedStudy = studyMap.get(completed.getStudy().getId());
+        if (completedStudy == null) {
+            log.warn("Completed study not found: {}", completed.getId());
+            return null;
+        }
+        return completedStudy;
+    }
+
+    private Study getNextStudy(UserStudy completed, List<Study> orderedStudies, Study completedStudy) {
+        Study nextStudy = findNextStudy(orderedStudies, completedStudy);
+        if (nextStudy == null) {
+            log.info("No next study found for user: {}, type: {}, devType: {}",
+                completed.getUserId(), completedStudy.getTypeId(), completedStudy.getDeveloperTypeId());
+            return null;
+        }
+        return nextStudy;
+    }
+
+    private boolean isSameStudyType(Study currentStudy, Study study) {
+        return study.getTypeId().equals(currentStudy.getTypeId()) &&
+            study.getDeveloperTypeId().equals(currentStudy.getDeveloperTypeId());
+    }
+}

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/word/WordCreationJobConfig.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/word/WordCreationJobConfig.java
@@ -11,30 +11,19 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
-import se.sowl.devlybatch.job.word.utils.WordContentProcessor;
-import se.sowl.devlybatch.job.word.utils.WordPromptManager;
 import se.sowl.devlybatch.job.study.service.StudyService;
+import se.sowl.devlybatch.job.word.service.WordProcessService;
 import se.sowl.devlydomain.study.domain.Study;
 import se.sowl.devlydomain.study.domain.StudyTypeEnum;
-import se.sowl.devlydomain.word.domain.Word;
-import se.sowl.devlydomain.word.repository.WordRepository;
-import se.sowl.devlyexternal.client.gpt.GPTClient;
-import se.sowl.devlyexternal.client.gpt.dto.GPTResponse;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class WordCreationJobConfig {
-
     private final StudyService studyService;
-    private final WordRepository wordRepository;
-    private final GPTClient gptClient;
-    private final WordContentProcessor wordContentProcessor;
-    private final WordPromptManager wordPromptManager;
+    private final WordProcessService wordProcessService;
 
     @Bean
     public Job wordCreationJob(JobRepository jobRepository, Step createWordsStep) {
@@ -53,35 +42,15 @@ public class WordCreationJobConfig {
             .build();
     }
 
-    private void createTodayWordStudies() {
+    public void createTodayWordStudies() {
         List<Study> todayStudies = studyService.getTodayStudiesOf(StudyTypeEnum.WORD.getId());
         for (Study study : todayStudies) {
-            GPTResponse response = getGptResponse(study);
-            saveWordsOf(study, response);
-            log.info("Created words for study {}", study.getId());
+            try {
+                Long studyId = wordProcessService.createWordsForStudy(study);
+                log.info("Successfully created words for study {}", studyId);
+            } catch (Exception e) {
+                log.error("Failed to create words for study {}: {}", study.getId(), e.getMessage(), e);
+            }
         }
-    }
-
-    private GPTResponse getGptResponse(Study study) {
-        String wordGeneratePrompt = createWordGeneratePrompt(study);
-        return gptClient.generate(wordContentProcessor.createGPTRequest(wordGeneratePrompt));
-    }
-
-    private String createWordGeneratePrompt(Study study) {
-        List<String> recentWords = wordRepository.findWordsByCreatedAtAfter(LocalDateTime.now().minusDays(7))
-            .stream().map(Word::getWord).collect(Collectors.toList());
-        return generatePrompt(study.getDeveloperTypeId(), recentWords);
-    }
-
-    private void saveWordsOf(Study study, GPTResponse response) {
-        List<Word> words = wordContentProcessor.parseGPTResponse(response, study.getId());
-        wordRepository.saveAll(words);
-    }
-
-    private String generatePrompt(Long developerTypeId, List<String> excludeWords) {
-        StringBuilder prompt = new StringBuilder();
-        wordPromptManager.addPrompt(developerTypeId, prompt);
-        wordPromptManager.addExcludePrompt(excludeWords, prompt);
-        return prompt.toString();
     }
 }

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/word/WordCreationJobConfig.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/word/WordCreationJobConfig.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 import se.sowl.devlybatch.job.word.utils.WordContentProcessor;
 import se.sowl.devlybatch.job.word.utils.WordPromptManager;
-import se.sowl.devlybatch.service.StudyService;
+import se.sowl.devlybatch.job.study.service.StudyService;
 import se.sowl.devlydomain.study.domain.Study;
 import se.sowl.devlydomain.study.domain.StudyTypeEnum;
 import se.sowl.devlydomain.word.domain.Word;

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/word/exception/EmptyWordsException.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/word/exception/EmptyWordsException.java
@@ -1,0 +1,7 @@
+package se.sowl.devlybatch.job.word.exception;
+
+public class EmptyWordsException extends RuntimeException{
+    public EmptyWordsException(String message) {
+        super(message);
+    }
+}

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/word/exception/WordCreationException.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/word/exception/WordCreationException.java
@@ -1,0 +1,7 @@
+package se.sowl.devlybatch.job.word.exception;
+
+public class WordCreationException extends RuntimeException {
+    public WordCreationException(String message, Exception error) {
+        super(message, error);
+    }
+}

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/word/service/WordContentProcessor.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/word/service/WordContentProcessor.java
@@ -1,4 +1,4 @@
-package se.sowl.devlybatch.job.word.utils;
+package se.sowl.devlybatch.job.word.service;
 
 import org.springframework.stereotype.Component;
 import se.sowl.devlybatch.common.gpt.GptContentProcessor;

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/word/service/WordProcessService.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/word/service/WordProcessService.java
@@ -1,0 +1,60 @@
+package se.sowl.devlybatch.job.word.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.sowl.devlybatch.job.word.exception.EmptyWordsException;
+import se.sowl.devlybatch.job.word.exception.WordCreationException;
+import se.sowl.devlydomain.study.domain.Study;
+import se.sowl.devlydomain.word.domain.Word;
+import se.sowl.devlydomain.word.repository.WordRepository;
+import se.sowl.devlyexternal.client.gpt.GPTClient;
+import se.sowl.devlyexternal.client.gpt.dto.GPTResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WordProcessService {
+    private final WordRepository wordRepository;
+    private final GPTClient gptClient;
+    private final WordContentProcessor wordContentProcessor;
+    private final WordPromptManager wordPromptManager;
+
+
+    @Transactional
+    public Long createWordsForStudy(Study study) {
+        try {
+            String prompt = createWordGeneratePrompt(study);
+            List<Word> words = createWordsFromGpt(study, prompt);
+            wordRepository.saveAll(words);
+            return study.getId();
+        } catch (Exception e) {
+            log.error("Error while creating words for study {}", study.getId(), e);
+            throw new WordCreationException("Failed to create words for study: " + study.getId(), e);
+        }
+    }
+
+    private List<Word> createWordsFromGpt(Study study, String prompt) {
+        GPTResponse response = gptClient.generate(wordContentProcessor.createGPTRequest(prompt));
+        List<Word> words = wordContentProcessor.parseGPTResponse(response, study.getId());
+        if (words.isEmpty()) {
+            throw new EmptyWordsException("No words parsed for study: " + study.getId());
+        }
+        return words;
+    }
+
+    private String createWordGeneratePrompt(Study study) {
+        List<String> recentWords = wordRepository.findWordsByCreatedAtAfter(LocalDateTime.now().minusDays(7))
+            .stream().map(Word::getWord).collect(Collectors.toList());
+
+        StringBuilder prompt = new StringBuilder();
+        wordPromptManager.addPrompt(study.getDeveloperTypeId(), prompt);
+        wordPromptManager.addExcludePrompt(recentWords, prompt);
+        return prompt.toString();
+    }
+}

--- a/devly-batch/src/main/java/se/sowl/devlybatch/job/word/service/WordPromptManager.java
+++ b/devly-batch/src/main/java/se/sowl/devlybatch/job/word/service/WordPromptManager.java
@@ -1,4 +1,4 @@
-package se.sowl.devlybatch.job.word.utils;
+package se.sowl.devlybatch.job.word.service;
 
 import org.springframework.stereotype.Component;
 import se.sowl.devlybatch.common.gpt.GptPromptManager;

--- a/devly-batch/src/main/resources/application.yml
+++ b/devly-batch/src/main/resources/application.yml
@@ -31,8 +31,14 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
         show_sql: true
+        batch_size: 100
+        order_inserts: true
+        generate_statistics: true
     hibernate:
       ddl-auto: create
+  batch:
+    retry-limit: 3
+    skip-limit: 10
 logging:
   level:
     org.hibernate.SQL: DEBUG
@@ -54,6 +60,8 @@ spring:
   batch:
     jdbc:
       initialize-schema: never
+    retry-limit: 3
+    skip-limit: 10
   h2:
     console:
       enabled: true
@@ -67,6 +75,8 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
+        batch_size: 100
+        order_inserts: true
     hibernate:
       ddl-auto: none
 openai:

--- a/devly-batch/src/test/java/se/sowl/devlybatch/common/gpt/GptContentProcessorTest.java
+++ b/devly-batch/src/test/java/se/sowl/devlybatch/common/gpt/GptContentProcessorTest.java
@@ -1,0 +1,143 @@
+package se.sowl.devlybatch.common.gpt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Profile;
+import se.sowl.devlybatch.common.gpt.exception.GPTContentProcessingException;
+import se.sowl.devlyexternal.client.gpt.dto.GPTResponse;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@Profile("test")
+class GptContentProcessorTest {
+
+    private static class TestGptContentProcessor extends GptContentProcessor<String> {
+        @Override
+        protected void parseEntity(Long studyId, String entry, List<String> contents) {
+            contents.add(entry.trim());
+        }
+    }
+
+    private TestGptContentProcessor processor;
+
+    @Mock
+    private GPTResponse mockResponse;
+
+    @BeforeEach
+    void setUp() {
+        processor = new TestGptContentProcessor();
+    }
+
+    @Test
+    @DisplayName("GPT 응답을 파싱하여 항목을 반환한다")
+    void parseResponse() {
+        // Given
+        Long studyId = 123L;
+        String responseContent = "Entry 1---Entry 2---Entry 3";
+        when(mockResponse.getContent()).thenReturn(responseContent);
+
+        // When
+        List<String> result = processor.parseGPTResponse(mockResponse, studyId);
+
+        // Then
+        assertEquals(3, result.size());
+        assertEquals("Entry 1", result.get(0));
+        assertEquals("Entry 2", result.get(1));
+        assertEquals("Entry 3", result.get(2));
+    }
+
+    @Test
+    @DisplayName("GPT 응답이 null일 때 예외를 던진다")
+    void throwErrorWhenNullResponse() {
+        // Given
+        Long studyId = 123L;
+
+        // When & Then
+        GPTContentProcessingException exception = assertThrows(
+            GPTContentProcessingException.class,
+            () -> processor.parseGPTResponse(null, studyId)
+        );
+        assertEquals("GPT response is null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("GPT 응답의 내용이 비어 있을 때 예외를 던진다")
+    void throwErrorWhenEmptyContent() {
+        // Given
+        Long studyId = 123L;
+        when(mockResponse.getContent()).thenReturn("");
+
+        // When & Then
+        GPTContentProcessingException exception = assertThrows(
+            GPTContentProcessingException.class,
+            () -> processor.parseGPTResponse(mockResponse, studyId)
+        );
+        assertEquals("GPT response content is empty", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("GPT 응답에 항목이 없을 때 예외를 던진다")
+    void throwErrorWhenGetEmptyGptResponse() {
+        // Given
+        Long studyId = 123L;
+        when(mockResponse.getContent()).thenReturn("---");
+
+        // When & Then
+        GPTContentProcessingException exception = assertThrows(
+            GPTContentProcessingException.class,
+            () -> processor.parseGPTResponse(mockResponse, studyId)
+        );
+        assertEquals("No entries found in GPT response", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("GPT 응답에서 유효한 항목을 파싱할 수 없을 때 예외를 던진다")
+    void throwWhenInvalidEntryParse() {
+        // Given
+        Long studyId = 123L;
+        GptContentProcessor<String> emptyProcessor = new GptContentProcessor<>() {
+            @Override
+            protected void parseEntity(Long studyId, String entry, List<String> contents) {
+                // 어떤 항목도 추가하지 않음
+            }
+        };
+        when(mockResponse.getContent()).thenReturn("Entry 1---Entry 2");
+
+        // When & Then
+        GPTContentProcessingException exception = assertThrows(
+            GPTContentProcessingException.class,
+            () -> emptyProcessor.parseGPTResponse(mockResponse, studyId)
+        );
+        assertEquals("Failed to parse any valid entities from GPT response", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("프롬프트가 null인 상태로 요청 시 예외를 던진다")
+    void throwErrorWhenNullRequestPrompt() {
+        // When & Then
+        GPTContentProcessingException exception = assertThrows(
+            GPTContentProcessingException.class,
+            () -> processor.createGPTRequest(null)
+        );
+        assertEquals("Prompt cannot be null or empty", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("프롬프트가 빈 문자열인 상태로 요청 시 예외를 던진다")
+    void throwErrorWhenEmptySpaceStringRequest() {
+        // When & Then
+        GPTContentProcessingException exception = assertThrows(
+            GPTContentProcessingException.class,
+            () -> processor.createGPTRequest("  ")
+        );
+        assertEquals("Prompt cannot be null or empty", exception.getMessage());
+    }
+}

--- a/devly-batch/src/test/java/se/sowl/devlybatch/job/pr/PrContentProcessorTest.java
+++ b/devly-batch/src/test/java/se/sowl/devlybatch/job/pr/PrContentProcessorTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-import se.sowl.devlybatch.job.pr.utils.PrContentProcessor;
+import se.sowl.devlybatch.job.pr.service.PrContentProcessor;
 import se.sowl.devlydomain.pr.domain.Pr;
 import se.sowl.devlydomain.pr.domain.PrChangedFile;
 import se.sowl.devlydomain.pr.domain.PrComment;

--- a/devly-batch/src/test/java/se/sowl/devlybatch/job/word/WordContentProcessorTest.java
+++ b/devly-batch/src/test/java/se/sowl/devlybatch/job/word/WordContentProcessorTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import se.sowl.devlybatch.job.word.utils.WordContentProcessor;
+import se.sowl.devlybatch.job.word.service.WordContentProcessor;
 import se.sowl.devlydomain.word.domain.Word;
 import se.sowl.devlyexternal.client.gpt.dto.GPTResponse;
 

--- a/devly-external/src/main/java/se/sowl/devlyexternal/client/gpt/exception/GPTClientException.java
+++ b/devly-external/src/main/java/se/sowl/devlyexternal/client/gpt/exception/GPTClientException.java
@@ -1,0 +1,7 @@
+package se.sowl.devlyexternal.client.gpt.exception;
+
+public class GPTClientException extends RuntimeException {
+    public GPTClientException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
config에 모든 코드를 작성되어 있어 코드를 보는데 불편함이 느껴졌다.
어디서 뭘 봐야하는지 의문이 오는 단계가 왔고, 서비스로 레이어로 역할을 분담시키면서 가독성과 유지보수성을 증가시켰다.

기존에는 중간 단계에서 실패하면 타입 스터디 도메인(pr, word)은 남아있지만 상세 정보 (words)가 없는 상황이 발생해,
더 정교한 트랜잭션 처리를 추가했다.